### PR TITLE
First  trivy scan using docker socket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/db3s?useSSL=false&serverTimezone=UTC&useLegacyDatetimeCode=false
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: 1q2w3e4r 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     networks: # Networks to join (Services on the same network can communicate with each other using their name)
       - backend
       - frontend
@@ -47,7 +49,6 @@ services:
 # Volumes
 volumes:
   db-data:
-
 # Networks to be created to facilitate communication between containers
 networks:
   backend:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,5 +9,9 @@ FROM openjdk:8-jdk-alpine
 WORKDIR /server
 #.jar file name depends on pom.xml project.build.finalName property, eg. <finalName>SpringApp</finalName>
 COPY --from=MAVEN_BUILD /server/target/server-0.0.1-SNAPSHOT.jar ./
+
+RUN apk update  \
+ && apk add  docker 
+
 EXPOSE 8080
 CMD java -jar ./server-0.0.1-SNAPSHOT.jar

--- a/server/src/main/java/com/project/server/Application.java
+++ b/server/src/main/java/com/project/server/Application.java
@@ -37,35 +37,7 @@ public class Application {
         return (args) -> {
 //            Users
 
-        try{    
-	
-        // Run a shell script
-
-        Process proc = Runtime.getRuntime().exec("docker run --rm  aquasec/trivy -f json --light python:3.4-alpine");
-        System.out.println("Success!");
-
-        BufferedReader stdInput = new BufferedReader(new 
-     InputStreamReader(proc.getInputStream()));
-
-BufferedReader stdError = new BufferedReader(new 
-     InputStreamReader(proc.getErrorStream()));
-
-// Read the output from the command
-System.out.println("Here is the standard output of the command:\n");
-String s = null;
-while ((s = stdInput.readLine()) != null) {
-    System.out.println(s);
-}
-
-// Read any errors from the attempted command
-System.out.println("Here is the standard error of the command (if any):\n");
-while ((s = stdError.readLine()) != null) {
-    System.out.println(s);
-}
-
-	} catch (IOException e) {
-		e.printStackTrace();
-	}
+        TrivyHandler.startTestcmd();
             ArrayList<User> testUsers = new ArrayList<>();
             testUsers.add(new User("admin", "admin"));
             testUsers.add(new User("user", "user"));

--- a/server/src/main/java/com/project/server/Application.java
+++ b/server/src/main/java/com/project/server/Application.java
@@ -12,6 +12,12 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import ch.qos.logback.core.html.NOPThrowableRenderer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.IOException;
 import java.sql.Date;
 import java.util.ArrayList;
 
@@ -30,6 +36,36 @@ public class Application {
                                   ProjectRepository projectRepo, ToolRepository toolRepo, ScanRepository scanRepo) {
         return (args) -> {
 //            Users
+
+        try{    
+	
+        // Run a shell script
+
+        Process proc = Runtime.getRuntime().exec("docker run --rm  aquasec/trivy -f json --light python:3.4-alpine");
+        System.out.println("Success!");
+
+        BufferedReader stdInput = new BufferedReader(new 
+     InputStreamReader(proc.getInputStream()));
+
+BufferedReader stdError = new BufferedReader(new 
+     InputStreamReader(proc.getErrorStream()));
+
+// Read the output from the command
+System.out.println("Here is the standard output of the command:\n");
+String s = null;
+while ((s = stdInput.readLine()) != null) {
+    System.out.println(s);
+}
+
+// Read any errors from the attempted command
+System.out.println("Here is the standard error of the command (if any):\n");
+while ((s = stdError.readLine()) != null) {
+    System.out.println(s);
+}
+
+	} catch (IOException e) {
+		e.printStackTrace();
+	}
             ArrayList<User> testUsers = new ArrayList<>();
             testUsers.add(new User("admin", "admin"));
             testUsers.add(new User("user", "user"));
@@ -54,7 +90,7 @@ public class Application {
                 u.getPermissions().add(userPermission);
                 userPermission.getUser().add(u);
             }
-
+            
             permissions.save(adminPermission);
             permissions.save(userPermission);
 

--- a/server/src/main/java/com/project/server/TrivyHandler.java
+++ b/server/src/main/java/com/project/server/TrivyHandler.java
@@ -1,0 +1,39 @@
+package com.project.server;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class TrivyHandler {
+    
+    public static void startTestcmd(){
+    
+        try{    
+            // Run a shell script
+        Process proc = Runtime.getRuntime().exec("docker run --rm  aquasec/trivy -f json --light python:3.4-alpine");
+        System.out.println("Success!");
+
+        BufferedReader stdInput = new BufferedReader(new 
+        InputStreamReader(proc.getInputStream()));
+
+        BufferedReader stdError = new BufferedReader(new 
+        InputStreamReader(proc.getErrorStream()));
+
+        // Read the output from the command
+        System.out.println("Here is the standard output of the command:\n");
+        String s = null;
+        while ((s = stdInput.readLine()) != null) {
+            System.out.println(s);
+        }
+
+        // Read any errors from the attempted command
+        System.out.println("Here is the standard error of the command (if any):\n");
+        while ((s = stdError.readLine()) != null) {
+            System.out.println(s);
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+             }
+    }
+}


### PR DESCRIPTION
po zainicjalizowaniu serwera włącza się skan jakiegoś obrazu z dockerhub.
Pytanie czy potrzebujemy klasę obsługująca argumenty od trivy(np —light) Czy skany będą przeprowadzane jednakowo i użytkownikom nie będzie zależało na dodatkowych opcjach?